### PR TITLE
changes to support more complex values and tags

### DIFF
--- a/src/Summernote.jsx
+++ b/src/Summernote.jsx
@@ -193,20 +193,19 @@ class ReactSummernote extends Component {
   }
 
   render() {
-    const { value, defaultValue, className } = this.props;
-    const html = value || defaultValue;
+    const { tag: Tag, children, className } = this.props;
 
     return (
       <div className={className}>
-        <div id={this.uid} dangerouslySetInnerHTML={{ __html: html }} />
+        <Tag id={this.uid}>{children}</Tag>
       </div>
     );
   }
 }
 
 ReactSummernote.propTypes = {
-  value: PropTypes.string,
-  defaultValue: PropTypes.string,
+  tag: PropTypes.string, // will determing using div or textarea field for form components like redux-form
+  children: PropTypes.node, // instead of value, using children makes more sense for div and textarea blocks
   codeview: PropTypes.bool,
   className: PropTypes.string,
   options: PropTypes.object,
@@ -222,4 +221,7 @@ ReactSummernote.propTypes = {
   onImageUpload: PropTypes.func
 };
 
+ReactSummernote.defaultProps = {
+  tag: 'div'
+};
 export default ReactSummernote;


### PR DESCRIPTION
These changes will comply with summernote documentation. Dev can set what type of tag they would like to use ( div or textarea ) which is also mentioned in original documentation. 
Also when there is a complex html content needs to be added as body, having only value as prop makes it very limited. instead using children prop would make it possible to wrap dynamic html content between component tags and pass it along to summernote.