### PR TITLE
Upgrade summernote

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "react-summernote",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Summernote (Super simple WYSIWYG editor) adaptation for react",
   "main": "./dist/react-summernote.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Vnkitaev/react-summernote.git"
+    "url": "https://github.com/Dakkers/react-summernote.git"
   },
   "scripts": {
     "build": "webpack",
@@ -32,7 +32,7 @@
   "dependencies": {
     "codemirror": "^5.26.0",
     "prop-types": "^15.5.10",
-    "summernote": "^0.8.3"
+    "summernote": "0.8.12"
   },
   "peerDependencies": {
     "bootstrap": "^3.3.6",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/react-summernote.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Dakkers/react-summernote.git"
+    "url": "https://github.com/summernote/react-summernote.git"
   },
   "scripts": {
     "build": "webpack",

--- a/yarn.lock
+++ b/yarn.lock
@@ -726,10 +726,6 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bootstrap@^3.3.7:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
-
 brace-expansion@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
@@ -2244,10 +2240,6 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-jquery@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
-
 js-base64@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
@@ -3610,12 +3602,10 @@ style-loader@^0.18.1:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
 
-summernote@^0.8.3:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/summernote/-/summernote-0.8.3.tgz#48ec5952a17c16d7a94538df9f93cd729faf2bdf"
-  dependencies:
-    bootstrap "^3.3.7"
-    jquery "^2.2.4"
+summernote@0.8.12:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/summernote/-/summernote-0.8.12.tgz#563502ed882abde9daab9db1e7eba330d37ac020"
+  integrity sha512-RVEJoIyztwPpopTwZvjag1WOvbmhUGFe6Mc9RADzzcX1ogG8pIXCB88icu/vjNYihITrzj2zZsoFMcDRHSlhEA==
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
I was unable to use the custom style tags with the specified version. Specifying 0.8.12 fixed it.