### PR TITLE
Update 'summernote' to v^0.8.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "codemirror": "^5.26.0",
     "prop-types": "^15.5.10",
-    "summernote": "^0.8.3"
+    "summernote": "^0.8.15"
   },
   "peerDependencies": {
     "bootstrap": "^3.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -726,10 +726,6 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bootstrap@^3.3.7:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
-
 brace-expansion@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
@@ -2244,9 +2240,10 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-jquery@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
+jquery@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.9:
   version "2.1.9"
@@ -3610,12 +3607,12 @@ style-loader@^0.18.1:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
 
-summernote@^0.8.3:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/summernote/-/summernote-0.8.3.tgz#48ec5952a17c16d7a94538df9f93cd729faf2bdf"
+summernote@^0.8.15:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/summernote/-/summernote-0.8.15.tgz#f783f23b2c1f85c1609855ad37205595147a3c39"
+  integrity sha512-52DYp7BWOLsAteMLHg+1pDgQMP5e6IfXmTpl4XnfY5JIMlOLUQtq6/5xwoV4C2d8T6xjvfuYJom9W2/4z28IeQ==
   dependencies:
-    bootstrap "^3.3.7"
-    jquery "^2.2.4"
+    jquery "^3.4.1"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Hello!

Since the distributed files bundle together dependencies at the time of publishing, it's not possible to load `react-summernote` with a version of `summernote` higher than 0.8.3 (* see edit).

Right now there's a bug in my consuming application that's fixed in `summernote@0.8.15`, so I would appreciate if we could get this merged and published under `react-summernote@2.0.1`.

Thanks in advance and also thank you for putting this wonderful editor out there! 🙏

**(*) EDIT:** Just noticing now that it is possible to do this by directly importing `'react-summernote/src/Summernote'` instead of `'react-summernote'`, and that's what I'm going to do as a workaround in the meantime, but that requires changing my build tooling so that it also builds this specific `node_modules` package, which makes my build config a little more complicated than it needs to be, so it would still be nice to not have to do this anyway.
