### PR TITLE
Insert text on the last caret position.

### DIFF
--- a/src/Summernote.jsx
+++ b/src/Summernote.jsx
@@ -173,7 +173,9 @@ class ReactSummernote extends Component {
   }
 
   insertText(text) {
-    this.editor.summernote('insertText', text);
+    this.editor.summernote('restoreRange');
+    this.editor.summernote('editor.insertText', text);
+    this.editor.summernote('saveRange');
   }
 
   get callbacks() {


### PR DESCRIPTION
Fix for insertText behavior.
In the current version, you can only insert text at the beginning. I add 2 lines
`this.editor.summernote('restoreRange');`
`this.editor.summernote('saveRange');`
This allows to insert text at the last caret position.